### PR TITLE
Feature/ecbuild35

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ ecbuild_include_mpi()
 link_libraries(${MPI_CXX_LIBRARIES} ${MPI_Fortran_LIBRARIES})
 
 # FMS
-find_package( fms 2020.3.0 REQUIRED )
+find_package( fms REQUIRED )
 include_directories( ${FMS_INCLUDE_DIRS} )
 
 ####################################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required( VERSION 3.3.2 FATAL_ERROR )
 
-project( fv3 C CXX Fortran )
+project( fv3 VERSION 1.0.0 LANGUAGES C CXX Fortran )
 
 set( CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH} )
 
@@ -30,7 +30,6 @@ ecbuild_requires_macro_version( 2.7 )
 ecbuild_declare_project()
 
 ecbuild_enable_fortran( REQUIRED )
-ecbuild_add_cxx11_flags()
 
 set( FV3_LINKER_LANGUAGE Fortran )
 
@@ -52,7 +51,7 @@ ecbuild_include_mpi()
 link_libraries(${MPI_CXX_LIBRARIES} ${MPI_Fortran_LIBRARIES})
 
 # FMS
-ecbuild_use_package( PROJECT fms REQUIRED )
+find_package( fms 2020.3.0 REQUIRED )
 include_directories( ${FMS_INCLUDE_DIRS} )
 
 ####################################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,10 +136,6 @@ ecbuild_add_library( TARGET          fv3
                      LINKER_LANGUAGE ${FV3_LINKER_LANGUAGE}
                    )
 
-if(OpenMP_Fortran_FOUND)
-  target_link_libraries(fv3 OpenMP::OpenMP_Fortran)
-endif()
-
 #GFortran-10 support
 if(CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
   target_compile_options(fv3 PRIVATE -fallow-argument-mismatch -fallow-invalid-boz)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ list( APPEND fv3_src_files
 ecbuild_add_library( TARGET          fv3
                      SOURCES         ${fv3_src_files}
                      LIBS            fms ${NETCDF_LIBRARIES} MPI::MPI_Fortran
+                     PRIVATE_INCLUDES ${PROJECT_SOURCE_DIR}
                      INSTALL_HEADERS LISTED
                      LINKER_LANGUAGE ${FV3_LINKER_LANGUAGE}
                    )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ set( FV3_LINKER_LANGUAGE Fortran )
 ####################################################################################################
 
 #openMP
-find_package( OpenMP COMPONENTS Fortran )
+ecbuild_enable_omp()
 
 # NetCDF
 set( NETCDF_F90 ON CACHE BOOL "Compile with Fortran NetCDF" )
@@ -52,7 +52,6 @@ link_libraries(${MPI_CXX_LIBRARIES} ${MPI_Fortran_LIBRARIES})
 
 # FMS
 find_package( fms REQUIRED )
-include_directories( ${FMS_INCLUDE_DIRS} )
 
 ####################################################################################################
 # Export package info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ find_package( OpenMP COMPONENTS Fortran )
 # NetCDF
 set( NETCDF_F90 ON CACHE BOOL "Compile with Fortran NetCDF" )
 find_package( NetCDF REQUIRED )
-include_directories( ${NETCDF_INCLUDE_DIR} )
+include_directories( ${NetCDF_INCLUDE_DIRS} )
 
 # MPI
 ecbuild_find_mpi( COMPONENTS CXX Fortran REQUIRED )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,9 @@ if(ECBUILD_INSTALL_FORTRAN_MODULES)
   install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR} DESTINATION ${INSTALL_INCLUDE_DIR} )
 endif()
 
+target_include_directories( fv3 INTERFACE $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>
+                                          $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>)
+
 ####################################################################################################
 # Finalise configuration
 ####################################################################################################


### PR DESCRIPTION
## Description

This is part of a series of PRs for a description see:

https://github.com/JCSDA-internal/fv3-bundle/pull/50

This introduces minor updates for compatibility with ecbuild 3.5.0

### Issue(s) addressed

Link the issues to be closed with this PR
- partially-fixes https://github.com/JCSDA-internal/jedi-stack/issues/19


## Acceptance Criteria (Definition of Done)

fv-bundle (without geos-aero, gsw, ropp) builds with the latest ecmwf release versions of ecbuild, eckit, fckit, and atlas, and all tests pass

## Dependencies

see https://github.com/JCSDA-internal/fv3-bundle/pull/50

## Impact

see https://github.com/JCSDA-internal/fv3-bundle/pull/50

## Test Data

None