### PR TITLE
Bugfix/pgi

### DIFF
--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -463,7 +463,7 @@ contains
 !> Namelist variables 
 !>       filtered_terrain  -  use orography maker filtered terrain mapping
 #ifdef __PGI
-      use GFS_restart, only : GFS_restart_type
+!!      use GFS_restart, only : GFS_restart_type
 
       implicit none
 #endif
@@ -1390,7 +1390,7 @@ contains
   subroutine get_ecmwf_ic( Atm, fv_domain )
 
 #ifdef __PGI
-      use GFS_restart, only : GFS_restart_type
+!!      use GFS_restart, only : GFS_restart_type
 
       implicit none
 #endif

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -3695,7 +3695,7 @@ contains
           if (present(Time)) then
              call get_date(Time, year, month, day, hour, minute, second)
              if (master) write(*,999) year, month, day, hour, minute, second
-999          format(' Range violation on: ', I4, '/', I02, '/', I02, ' ', I02, ':', I02, ':', I02)
+999          format(' Range violation on: ', I4, '/', I2, '/', I2, ' ', I2, ':', I2, ':', I2)
           endif
           if ( present(bad_range) ) then
                bad_range = .true. 
@@ -3760,7 +3760,7 @@ contains
           if (present(Time)) then
              call get_date(Time, year, month, day, hour, minute, second)
              if (master) write(*,999) year, month, day, hour, minute, second
-999          format(' Range violation on: ', I4, '/', I02, '/', I02, ' ', I02, ':', I02, ':', I02)
+999          format(' Range violation on: ', I4, '/', I2, '/', I2, ' ', I2, ':', I2, ':', I2)
           endif
           if ( present(bad_range) ) then
                bad_range = .true. 


### PR DESCRIPTION
## Description

This is needed to get this repo to compile with PGI compilers.

Two main changes are needed.  pgf90 does not like using leading zeros in format statements. 

And, I had to comment out the use of the `GFS_restart` module, which is only enable for PGI compilers, and which does not exist in this repo or the fms repo.    It does seem to exist at least in the [EMC version of fv3atm](https://github.com/NOAA-EMC/fv3atm/blob/production/GFS_v15/gfsphysics/GFS_layer/GFS_restart.F90) but it appears that it is not used here, even for PGI compilers.

I'm not sure if I should direct this PR to upstream?

### Issue(s) addressed

Link the issues to be closed with this PR
- partially-fixes #https://github.com/JCSDA-internal/jedi-stack/issues/81

## Acceptance Criteria (Definition of Done)

This repo compiles on Summit with the PGI 20.1 compiler suite

## Dependencies

None

## Impact

None

## Test Data

None